### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/cloudformation/School-Analytics-Demo-Resources.json
+++ b/cloudformation/School-Analytics-Demo-Resources.json
@@ -73,7 +73,7 @@
           "Fn::GetAtt": ["IAMRoleBasicLambda", "Arn"]
         },
         "Timeout": 360,
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
 
         "Code": {
           "ZipFile": {
@@ -180,7 +180,7 @@
           "Fn::GetAtt": ["IAMRoleBasicLambda", "Arn"]
         },
         "Timeout": 360,
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
 
         "Code": {
           "ZipFile": {


### PR DESCRIPTION
CloudFormation templates in aws-school-data-analytics have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.